### PR TITLE
11 proxy repository only accepts auth type of username

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ nexus3_repositories.**list_all**():
         salt myminion nexus3_repositories.list_all
 
 
-nexus3_repositories.**proxy**(*name,format,remote_url,apt_dist_name='bionic',apt_flat_repo=False,blobstore='default',bower_rewrite_urls=True,cleanup_policies=[],content_max_age=1440,docker_force_auth=True,docker_http_port=None,docker_https_port=None,docker_index_type='HUB',docker_index_url=None,docker_index_type='HUB',docker_index_url=None,docker_v1_enabled=False,maven_layout_policy='STRICT',maven_version_policy='MIXED',metadata_max_age=1440,nuget_cache_max_age=3600,remote_password=None,remote_username=None,strict_content_validation=True*):
+nexus3_repositories.**proxy**(*name,format,remote_url,apt_dist_name='bionic',apt_flat_repo=False,blobstore='default',bower_rewrite_urls=True,cleanup_policies=[],content_max_age=1440,docker_force_auth=True,docker_http_port=None,docker_https_port=None,docker_index_type='HUB',docker_index_url=None,docker_index_type='HUB',docker_index_url=None,docker_v1_enabled=False,maven_layout_policy='STRICT',maven_version_policy='MIXED',metadata_max_age=1440,ntlm_domain=None,ntlm_host=None,nuget_cache_max_age=3600,remote_auth_type='username',remote_bearer_token=None,remote_password=None,remote_username=None,strict_content_validation=True*):
 
     Nexus 3 supports many different formats.  The apt, bower, docker, maven, and nuget formats have built-in arguments.
 
@@ -648,8 +648,26 @@ nexus3_repositories.**proxy**(*name,format,remote_url,apt_dist_name='bionic',apt
     metadata_max_age (int):
         Max age of metadata cache in seconds (Default: 1440)
 
+    ntlm_domain (str):
+        NTLM domain (Default: None)
+
+    ntlm_host (str):
+        NTLM Host (Default: None)
+
     nuget_cache_max_age (int):
         Nuget cache max age in seconds (Default: 3600)
+
+    remote_auth_type (str):
+        Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
+
+    remote_bearer_token (str):
+        Bearer Token for remote url (Default: None)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
 
     remote_password (str):
         Password for remote url (Default: None)

--- a/_modules/nexus3_repositories.py
+++ b/_modules/nexus3_repositories.py
@@ -477,9 +477,14 @@ def proxy(name,
 
     remote_auth_type (str):
         Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
 
     remote_bearer_token (str):
-        Bearer Token for remote url (Default: None)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
 
     remote_password (str):
         Password for remote url (Default: None)

--- a/_modules/nexus3_repositories.py
+++ b/_modules/nexus3_repositories.py
@@ -394,6 +394,7 @@ def proxy(name,
         ntlm_host=None,
         nuget_cache_max_age=3600,
         remote_auth_type='username',
+        remote_bearer_token=None,
         remote_password=None,
         remote_username=None,
         strict_content_validation=True):
@@ -477,6 +478,9 @@ def proxy(name,
     remote_auth_type (str):
         Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
 
+    remote_bearer_token (str):
+        Bearer Token for remote url (Default: None)
+
     remote_password (str):
         Password for remote url (Default: None)
 
@@ -545,7 +549,7 @@ def proxy(name,
         'bearerToken': {
             'authentication': {
                 'type': 'bearerToken',
-                'bearerToken': remote_password
+                'bearerToken': remote_bearer_token
             },
         },
         'ntlm': {
@@ -602,7 +606,7 @@ def proxy(name,
         }
     }
 
-    if remote_username is not None or remote_password is not None:
+    if remote_auth_type in ['username', 'bearerToken','ntlm'] and (remote_username is not None or remote_bearer_token is not None):
         payload['httpClient'].update(auth[remote_auth_type])
 
     if cleanup_policies:

--- a/_modules/nexus3_repositories.py
+++ b/_modules/nexus3_repositories.py
@@ -390,7 +390,10 @@ def proxy(name,
         maven_layout_policy='STRICT',
         maven_version_policy='MIXED',
         metadata_max_age=1440,
+        ntlm_domain=None,
+        ntlm_host=None,
         nuget_cache_max_age=3600,
+        remote_auth_type='username',
         remote_password=None,
         remote_username=None,
         strict_content_validation=True):
@@ -465,6 +468,15 @@ def proxy(name,
     nuget_cache_max_age (int):
         Nuget cache max age in seconds (Default: 3600)
 
+    ntlm_domain (str):
+        NTLM domain (Default: None)
+
+    ntlm_host (str):
+        NTLM Host (Default: None)
+
+    remote_auth_type (str):
+        Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
+
     remote_password (str):
         Password for remote url (Default: None)
 
@@ -521,12 +533,30 @@ def proxy(name,
         'routingRule': 'string'
     }
 
+    # auth dictionary that filters on remote_auth_type
     auth =  {
-        'authentication': {
-            'type': 'username',
-            'username': remote_username,
-            'password': remote_password
-        }
+        'username': {
+            'authentication': {
+                'type': 'username',
+                'username': remote_username,
+                'password': remote_password
+            },
+        },
+        'bearerToken': {
+            'authentication': {
+                'type': 'bearerToken',
+                'bearerToken': remote_password
+            },
+        },
+        'ntlm': {
+            'authentication': {
+                'type': 'ntlm',
+                'username': remote_username,
+                'password': remote_password,
+                'ntlmDomain': ntlm_domain,
+                'ntlmHost': ntlm_host,
+            },
+        },
     }
 
     cleanup = {
@@ -572,8 +602,8 @@ def proxy(name,
         }
     }
 
-    if remote_username is not None:
-        payload['httpClient'].update(auth)
+    if remote_username is not None or remote_password is not None:
+        payload['httpClient'].update(auth[remote_auth_type])
 
     if cleanup_policies:
         payload.update(cleanup)

--- a/_states/nexus3_repositories.py
+++ b/_states/nexus3_repositories.py
@@ -400,20 +400,22 @@ def present(name,
             if metadata_max_age != repo['proxy']['metadataMaxAge']:
                 updates['metadata_max_age'] = metadata_max_age
                 is_update = True
+
+            # check for changes in authentication
+            if repo['httpClient']['authentication'] and remote_auth_type is None:
+                updates['remote_auth_type'] = remote_auth_type
+                is_update = True
             if repo['httpClient']['authentication'] and remote_auth_type is not None:
                 if remote_auth_type != repo['httpClient']['authentication']['type']:
                     updates['remote_auth_type'] = remote_auth_type
                     is_update = True
                 
                 if remote_auth_type == 'username' or remote_auth_type == 'ntlm':
-                    try:
-                        if remote_username != repo['httpClient']['authentication']['username']:
+                    if repo['httpClient']['authentication'] is None:
+                        updates['remote_username'] = remote_username                    
+                    elif remote_username != repo['httpClient']['authentication']['username']:
                             updates['remote_username'] = remote_username
-                    except:
-                        # assume that repo['httpClient']['authentication']['username'] resulted
-                        # in a keyerror because it does exist yet
-                        if remote_username is not None:
-                            updates['remote_username'] = remote_username
+                            is_update = True
                     # cannot compare passwords so always set it as new
                     if remote_password is not None:
                         updates['remote_password'] = '*******'

--- a/_states/nexus3_repositories.py
+++ b/_states/nexus3_repositories.py
@@ -185,9 +185,15 @@ def present(name,
 
     remote_auth_type (str):
         Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
 
     remote_bearer_token (str):
         Bearer Token for remote url (Default: None)
+        .. note::
+            Setting the bearerToken value currently does work with the REST API.  This will have to be set in the UI for now.
+            https://github.com/sonatype/nexus-public/issues/247
 
     remote_password (str):
         Password for remote url (Default: None)

--- a/_states/nexus3_repositories.py
+++ b/_states/nexus3_repositories.py
@@ -88,7 +88,10 @@ def present(name,
         maven_layout_policy='STRICT',
         maven_version_policy='MIXED',
         metadata_max_age=1440,
+        ntlm_domain=None,
+        ntlm_host=None,
         nuget_cache_max_age=3600,
+        remote_auth_type='username',
         remote_password=None,
         remote_url='',
         remote_username=None,
@@ -170,8 +173,17 @@ def present(name,
     metadata_max_age (int):
         Max age of metadata cache in seconds (Default: 1440)
 
+    ntlm_domain (str):
+        NTLM domain (Default: None)
+
+    ntlm_host (str):
+        NTLM Host (Default: None)
+
     nuget_cache_max_age (int):
         Nuget cache max age in seconds (Default: 3600)
+
+    remote_auth_type (str):
+        Authentication type for remote url [username|ntlm|bearerToken] (Default: username)
 
     remote_password (str):
         Password for remote url (Default: None)
@@ -385,7 +397,8 @@ def present(name,
                 updates['metadata_max_age'] = metadata_max_age
                 is_update = True
             if repo['httpClient']['authentication']:
-                if remote_username is None:
+                if remote_username is None or remote_password is not None:
+                    updates['remote_auth_type'] = remote_auth_type
                     updates['remote_username'] = remote_username
                     updates['remote_username'] = remote_password
                     is_update = True
@@ -393,6 +406,9 @@ def present(name,
                 # if remote_password != repo['httpClient']['authentication']['password']:
                 #     updates['remote_password'] = remote_password
                 #     is_update = True
+                if remote_password != repo['httpClient']['authentication']['remote_auth_type']:
+                    updates['remote_auth_type'] = remote_auth_type
+                    is_update = True
                 if remote_username != repo['httpClient']['authentication']['username']:
                     updates['remote_username'] = remote_username
                     is_update = True
@@ -477,6 +493,8 @@ def present(name,
                                                     maven_layout_policy,
                                                     maven_version_policy,
                                                     metadata_max_age,
+                                                    ntlm_domain,
+                                                    ntlm_host,
                                                     nuget_cache_max_age,
                                                     remote_password,
                                                     remote_username,

--- a/test-env/pillar/nexus/init.sls
+++ b/test-env/pillar/nexus/init.sls
@@ -48,6 +48,15 @@ nexus:
       - docker_http_port: 5001
       - docker_force_auth: False
       - docker_index_type: HUB
+    npm-proxy:
+      - format: npm
+      - type: proxy
+      - remote_url: https://npm.somerepo.com/
+      # currently setting the bearer token for NPM is not possible
+      # with the Nexus REST API at this time.
+      # https://github.com/sonatype/nexus-public/issues/247
+      # - remote_auth_type: bearerToken
+      # - remote_bearer_token: password
     yum-proxy:
       - format: yum
       - type: proxy


### PR DESCRIPTION
- Added arguments to proxy repositories to specify `remote_auth_type`, `remote_bearer_token`, `ntlm_domain`, and `ntlm_host`.

Unfortunately this cannot be used to set the bearer token for NPM repositories because the Nexus REST API does not appear to support doing so or is broken.
https://github.com/sonatype/nexus-public/issues/247